### PR TITLE
升级alidayu的SDK，去掉与新版支付宝的类名冲突

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>taobao</groupId>
 			<artifactId>sdk-java</artifactId>
-			<version>auto_1447355351010-20151113</version>
+			<version>auto_1455552377940-20160607</version>
 		</dependency>
 	<!-- <dependency> -->
 	<!-- <groupId>org.codehaus.plexus</groupId> -->

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>taobao</groupId>
 			<artifactId>sdk-java</artifactId>
-			<version>auto_1455552377940-20160607</version>
+			<version>auto_1455552377940-20170331</version>
 		</dependency>
 	<!-- <dependency> -->
 	<!-- <groupId>org.codehaus.plexus</groupId> -->

--- a/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
+++ b/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
@@ -55,10 +55,8 @@ public class Alidayu {
 		this.signName = conf.getProperty(SingName, "地藤");
 	}
 
-	public boolean send(String corpNo, Object data) {
+	public boolean send(String corpNo, String json) {
 		AlibabaAliqinFcSmsNumSendRequest req = new AlibabaAliqinFcSmsNumSendRequest();
-		req.setRecNum(mobileNo);
-		req.setSmsTemplateCode(this.templateNo);
 		String serverUrl = this.serverUrl;
 		String appKey = this.appKey;
 		String appSecret = this.appSecret;
@@ -81,8 +79,12 @@ public class Alidayu {
 		req.setExtend(corpNo);
 		req.setSmsType("normal");
 		req.setSmsFreeSignName(this.signName);
+
 		// 活动验证, 变更验证，登录验证，注册验证，身份验证
-		req.setSmsParam(data);
+		req.setSmsParamString(json);// 短信模版变量
+
+		req.setRecNum(mobileNo);
+		req.setSmsTemplateCode(this.templateNo);
 		AlibabaAliqinFcSmsNumSendResponse rsp;
 
 		try {

--- a/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
+++ b/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
@@ -55,8 +55,8 @@ public class Alidayu {
 		this.signName = conf.getProperty(SingName, "地藤");
 	}
 
-	public boolean send(String corpNo, String json) {
-		AlibabaAliqinFcSmsNumSendRequest req = new AlibabaAliqinFcSmsNumSendRequest();
+	public boolean send(String corpNo, String smsParam) {
+
 		String serverUrl = this.serverUrl;
 		String appKey = this.appKey;
 		String appSecret = this.appSecret;
@@ -74,21 +74,21 @@ public class Alidayu {
 			return false;
 		}
 
-		String sessionKey = "";
 		TaobaoClient client = new DefaultTaobaoClient(serverUrl, appKey, appSecret);
+		AlibabaAliqinFcSmsNumSendRequest req = new AlibabaAliqinFcSmsNumSendRequest();
 		req.setExtend(corpNo);
 		req.setSmsType("normal");
 		req.setSmsFreeSignName(this.signName);
 
-		// 活动验证, 变更验证，登录验证，注册验证，身份验证
-		req.setSmsParamString(json);// 短信模版变量
+		req.setSmsParamString(smsParam);
+		// req.setSmsParamString("{code:'785456',product:'阿里大于'}");
 
 		req.setRecNum(mobileNo);
 		req.setSmsTemplateCode(this.templateNo);
 		AlibabaAliqinFcSmsNumSendResponse rsp;
 
 		try {
-			rsp = client.execute(req, sessionKey);
+			rsp = client.execute(req);
 			BizResult result = rsp.getResult();
 			if (result != null) {
 				if (result.getSuccess()) {

--- a/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
+++ b/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
@@ -56,7 +56,6 @@ public class Alidayu {
 	}
 
 	public boolean send(String corpNo, String smsParam) {
-
 		String serverUrl = this.serverUrl;
 		String appKey = this.appKey;
 		String appSecret = this.appSecret;
@@ -79,13 +78,12 @@ public class Alidayu {
 		req.setExtend(corpNo);
 		req.setSmsType("normal");
 		req.setSmsFreeSignName(this.signName);
-
-		req.setSmsParamString(smsParam);
-		// req.setSmsParamString("{code:'785456',product:'阿里大于'}");
-
+		req.setSmsParamString(smsParam.toString());
 		req.setRecNum(mobileNo);
 		req.setSmsTemplateCode(this.templateNo);
 		AlibabaAliqinFcSmsNumSendResponse rsp;
+
+		log.info(req.getTextParams());
 
 		try {
 			rsp = client.execute(req);

--- a/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
+++ b/src/main/java/cn/cerc/jdb/aliyu/Alidayu.java
@@ -99,6 +99,7 @@ public class Alidayu {
 					return false;
 				}
 			} else {
+				log.info(rsp.getBody());
 				message = "Alidayu error: rsp.getResult is null, app host: " + appName;
 				return false;
 			}

--- a/src/main/java/cn/cerc/jdb/aliyu/AlidayuTest.java
+++ b/src/main/java/cn/cerc/jdb/aliyu/AlidayuTest.java
@@ -28,7 +28,7 @@ public class AlidayuTest {
 		});
 		sms.setMobileNo("13912345678");
 		sms.setTemplateNo("SMS_1190006");
-		boolean ok = sms.send("000000", this);
+		boolean ok = sms.send("000000", "");
 		System.out.println(sms.getMessage());
 		assertTrue(ok);
 	}

--- a/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
+++ b/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
@@ -32,8 +32,8 @@ public class AlidayuTest {
 		sms.setMobileNo("18566767108");
 		sms.setTemplateNo("SMS_1190006");
 
-		String json = "{\"code\":\"123\",\"product\":\"567\"}";
-		boolean ok = sms.send("911001", json);
+		String smsParam = "{code:'785456',product:'阿里大于'}";
+		boolean ok = sms.send("911001", smsParam);
 		System.out.println(sms.getMessage());
 		assertTrue(ok);
 	}

--- a/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
+++ b/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
@@ -2,7 +2,6 @@ package cn.cerc.jdb.aliyu;
 
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import cn.cerc.jdb.core.IConfig;
@@ -10,25 +9,31 @@ import cn.cerc.jdb.core.IConfig;
 public class AlidayuTest {
 
 	@Test
-	@Ignore
-	public void test() {
+	public void testSend() {
 		Alidayu sms = new Alidayu(new IConfig() {
 
 			@Override
 			public String getProperty(String key, String def) {
+
+				if (Alidayu.AppName.equals(key))
+					return "地藤";
+				if (Alidayu.ServerUrl.equals(key))
+					return "http://gw.api.taobao.com/router/rest";
 				if (Alidayu.AppKey.equals(key))
-					return "appkey";
+					return "23256148";
 				if (Alidayu.AppSecret.equals(key))
-					return "appsecret";
+					return "8f8a19b62ac55b11ed3b7a0c241f218d";
 				if (Alidayu.SingName.equals(key))
-					return "我的应用";
+					return "地藤";
 				return null;
 			}
-
 		});
-		sms.setMobileNo("13912345678");
+
+		sms.setMobileNo("18566767108");
 		sms.setTemplateNo("SMS_1190006");
-		boolean ok = sms.send("000000", "");
+
+		String json = "{\"code\":\"123\",\"product\":\"567\"}";
+		boolean ok = sms.send("911001", json);
 		System.out.println(sms.getMessage());
 		assertTrue(ok);
 	}

--- a/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
+++ b/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
@@ -30,9 +30,9 @@ public class AlidayuTest {
 		});
 
 		sms.setMobileNo("18566767108");
-		sms.setTemplateNo("SMS_1190006");
+		sms.setTemplateNo("SMS_1190007");
 
-		String smsParam = "{code:'785456',product:'阿里大于'}";
+		String smsParam = "{code:'785456',product:'地藤系统'}";
 		boolean ok = sms.send("911001", smsParam);
 		System.out.println(sms.getMessage());
 		assertTrue(ok);

--- a/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
+++ b/src/test/java/cn/cerc/jdb/aliyu/AlidayuTest.java
@@ -16,13 +16,13 @@ public class AlidayuTest {
 			public String getProperty(String key, String def) {
 
 				if (Alidayu.AppName.equals(key))
-					return "地藤";
+					return "serverName";
 				if (Alidayu.ServerUrl.equals(key))
 					return "http://gw.api.taobao.com/router/rest";
 				if (Alidayu.AppKey.equals(key))
-					return "23256148";
+					return "appKey";
 				if (Alidayu.AppSecret.equals(key))
-					return "8f8a19b62ac55b11ed3b7a0c241f218d";
+					return "appSecret";
 				if (Alidayu.SingName.equals(key))
 					return "地藤";
 				return null;


### PR DESCRIPTION
更新该SDK主要为了解决
` 与新版支付宝同名的DefaultAlipayClient `

同时，改进了发送消息的模板，支持用户自定义的模板信息发送，主要以json数据传入，例如
`req.setSmsParamString("{\"code\":\"1234\",\"product\":\"alidayu\"}");
`

需要改动的地方较多，请暂时不要合并